### PR TITLE
Remove reek version from hound.yml

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -5,7 +5,6 @@ rubocop:
   config_file: .rubocop.yml
 
 reek:
-  version: 5.0.2
   enabled: true
 
   config_file: .reek.yml


### PR DESCRIPTION
Удалена строка c версией reek в hound.yml с целью избежать ошибки hound

![изображение](https://user-images.githubusercontent.com/29785537/62615356-9b670480-b8fc-11e9-89cf-ba98a92a83bf.png)
